### PR TITLE
Feature/update api version

### DIFF
--- a/METno.php
+++ b/METno.php
@@ -5,13 +5,13 @@
  * @copyright iMakers, s.r.o.
  * @copyright Martin Kluska
  * @web http://imakers.cz
- * 
- * 
- * 
+ *
+ *
+ *
  * @todo info about location, should be added to METnoDay too
  * @todo time by location
  * @todo detection of night by sunset
- * 
+ *
  * @uses METnoFactory
  * @uses METnoDay
  * @uses METnoSymbol
@@ -19,7 +19,7 @@
  */
 class METno extends METnoFactory {
 
-    protected $apiRequest       = "http://api.met.no/weatherapi/locationforecast/1.9/?";
+    protected $apiRequest       = "https://api.met.no/weatherapi/locationforecast/1.9/?";
     protected $apiParameters    = "";
 
     /**
@@ -28,15 +28,15 @@ class METno extends METnoFactory {
      */
     protected $error            = false;
     protected $errorHTML        = "";
-    
+
     protected $forecastByDay    = array();
 
     /**
      * Constructs METno class with specified $lat $lon location and option seelevel
-     * 
+     *
      * @param <decimal>         $lat
      * @param <decimal>         $lon
-     * @param <int|boolean>     $seeLevel - meters 
+     * @param <int|boolean>     $seeLevel - meters
      */
     public function __construct($lat, $lon, $seeLevel = false) {
         $this->apiParameters       .= "lat=$lat;lon=$lon";
@@ -60,6 +60,7 @@ class METno extends METnoFactory {
             curl_setopt($curl, CURLOPT_URL, $url);
             curl_setopt($curl, CURLOPT_HEADER, 0);
             curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
 
             curl_setopt($curl, CURLOPT_USERAGENT, 'Mozilla/5.001 (windows; U; NT4.0; en-US; rv:1.0) Gecko/25250101');
 
@@ -82,7 +83,7 @@ class METno extends METnoFactory {
 
     /**
      * Genereates HTML Error and displays it if die on error is active
-     * If die on error is not active, the html and Exception is saved for 
+     * If die on error is not active, the html and Exception is saved for
      * internal use
      * @param <Exception> $e
      * @return boolean
@@ -94,23 +95,23 @@ class METno extends METnoFactory {
         $this->errorHTML .= "<tr><td style='padding-right: 10px;text-align:right;'>Code </td><td> " . $e->getCode() . "</td></tr>";
         $this->errorHTML .= "<tr><td style='padding-right: 10px;text-align:right;'>Message </td><td> " . $e->getMessage() . "</td></tr>";
         $this->errorHTML .= "</table><h3>Stack trace</h3>";
-       
+
         foreach ($e->getTrace() as $trace) {
             $this->errorHTML        .="<p>";
             if (isset($trace["class"]) && $trace['class'] != '') {
                 $this->errorHTML    .= $trace['class'];
                 $this->errorHTML    .= '->';
             }
-            
+
             $this->errorHTML        .= $trace['function'];
             $this->errorHTML        .= '(';
             if (!empty($trace["args"])) {
                 $first  = true;
-                
+
                 foreach($trace["args"] as $argument) {
                     if (is_string($argument)) {
                         if ($first) {
-                            $first  = false;                        
+                            $first  = false;
                         } else {
                             $this->errorHTML.=",";
                         }
@@ -121,7 +122,7 @@ class METno extends METnoFactory {
             $this->errorHTML        .= ');<br />';
         }
         $this->errorHTML .= "</table>";
-        
+
         if (self::$dieOnError) {
             header("Content-type: text/html; charset=utf-8");
             die($this->errorHTML);
@@ -136,7 +137,7 @@ class METno extends METnoFactory {
 
         return false;
     }
-    
+
     /**
      * Detects if there was an error during parsing xml
      * @return type
@@ -144,11 +145,11 @@ class METno extends METnoFactory {
     public function isError() {
         return is_object($this->error);
     }
-    
+
     public function isSuccess() {
         return !is_object($this->error);
     }
-    
+
     /**
      * Return today forecast wich can be printed/echo to get current temperature
      * @return METnoForecast
@@ -156,7 +157,7 @@ class METno extends METnoFactory {
     public function today() {
         return $this->getForecastForDate(date("Y-m-d"));
     }
-    
+
     /**
      * Return tomorrows forecast wich can be printed/echo to get current temperature
      * @return METnoForecast
@@ -164,7 +165,7 @@ class METno extends METnoFactory {
     public function tomorrow() {
         return $this->getForecastForDate(date("Y-m-d", strtotime("+1 DAY")));
     }
-    
+
     /**
      * Return forecast in 2 days wich can be printed/echo to get current temperature
      * @return METnoForecast
@@ -172,7 +173,7 @@ class METno extends METnoFactory {
     public function in2Days() {
         return $this->getForecastForDate(date("Y-m-d",  strtotime("+2 DAY")));
     }
-    
+
     /**
      * Return forecast in 3 days wich can be printed/echo to get current temperature
      * @return METnoForecast
@@ -180,7 +181,7 @@ class METno extends METnoFactory {
     public function in3Days() {
         return $this->getForecastForDate(date("Y-m-d",  strtotime("+3 DAY")));
     }
-    
+
     /**
      * Return forecast in 4 days wich can be printed/echo to get current temperature
      * @return METnoForecast
@@ -188,7 +189,7 @@ class METno extends METnoFactory {
     public function in4Days() {
         return $this->getForecastForDate(date("Y-m-d",  strtotime("+4 DAY")));
     }
-    
+
     /**
      * Return forecast in 5 days wich can be printed/echo to get current temperature
      * @return METnoForecast
@@ -196,27 +197,27 @@ class METno extends METnoFactory {
     public function in5Days() {
         return $this->getForecastForDate(date("Y-m-d",  strtotime("+5 DAY")));
     }
-    
+
     public function getForecastForXDays($count) {
-        
+
         $current    = 0;
         $forecast   = array();
-        
-        foreach ($this->forecastByDay as $date => $forecastForDay) {    
+
+        foreach ($this->forecastByDay as $date => $forecastForDay) {
             $forecast[$date]     = $forecastForDay;
             $current++;
             if ($current == $count) {
                 break;
             }
         }
-        
+
         return $forecast;
     }
 
     /**
-     * < GEThers >  
+     * < GEThers >
      */
-    
+
     /**
      * Returns Exception object if an error has occurred
      * @return <Exception>|boolean
@@ -244,9 +245,9 @@ class METno extends METnoFactory {
             return "No error has occurred";
         }
     }
-    
+
     /**
-     * 
+     *
      * @return boolean
      * @throws Exception
      */
@@ -254,133 +255,133 @@ class METno extends METnoFactory {
         if (!empty($this->forecastByDay)) {
             return $this->forecastByDay;
         }
-        
+
         $xml    = $this->getForecastXML();
-        
+
         if (!is_bool($xml)) {
             try {
-                
+
                 /**
-                 * Container with time entries by day 
+                 * Container with time entries by day
                  */
                 $forecastByDay = array();
                 $previousDay = null;
                 $lastForeCast = null;
-                
+
                 foreach ($xml->product->time as $forecast) {
-                    
+
                     $forecastAttributes                     = $forecast->attributes();
                     if (isset($forecast->location)) {
-                        
+
                         if (isset($forecastAttributes["datatype"]) && isset($forecastAttributes["from"]) && $forecastAttributes["to"]) {
                             $fromValue                              = self::getAttributeValue($forecastAttributes, "from");
-                            $toValue                                = self::getAttributeValue($forecastAttributes, "to");                            
-                            
+                            $toValue                                = self::getAttributeValue($forecastAttributes, "to");
+
                             if (!is_bool($fromValue) && !is_bool($toValue)) {
-                                
+
                                 $fromDate                           = self::getDate($fromValue);
                                 $fromHour                           = self::getHour($fromValue);
                                 $toHour                             = self::getHour($toValue);
-                               
-                        
+
+
                                 if (!is_bool($fromDate) && !is_bool($toHour) && !is_bool($fromHour)) {
-                                    
+
                                     // check the previus day data if have all
                                     if (!is_null($previousDay) && $previousDay != $fromDate) {
                                         $hasData = false;
-                                        
+
                                          foreach ($forecastByDay[$previousDay] as $hour) {
                                              if (is_object($hour["detail"])) {
                                                  $hasData = true;
                                              }
                                          }
-                                         
+
                                          if (!$hasData) {
                                              // add to last hour the forecast location
                                              $hour = key($forecastByDay[$previousDay]);
                                              $forecastByDay[$previousDay][$hour]["detail"] = $lastForeCast->location;
                                          }
                                     }
-                    
+
                                     /**
                                      * Prepare containers by date and then for hour
                                      */
                                     if (!isset($forecastByDay[$fromDate])) {
                                         $forecastByDay[$fromDate]   = array();
                                     }
-                                    
+
                                     if (!isset($forecastByDay[$fromDate][$toHour])) {
                                         $forecastByDay[$fromDate][$toHour] = array(
                                             "detail"    => 0,
                                             "symbols"   => array()
                                         );
                                     }
-                                    
+
                                     if (!isset($forecastByDay[$fromDate][$fromHour])) {
                                         $forecastByDay[$fromDate][$fromHour] = array(
                                             "detail"    => 0,
                                             "symbols"   => array()
                                         );
                                     }
-                                    
+
                                     /**
                                      * Detect if the element is weather info or
                                      * symbol info and insert it into the correct containe
                                      */
-                                    if ($fromHour == $toHour) {                                        
+                                    if ($fromHour == $toHour) {
                                         $forecastByDay[$fromDate][$toHour]["detail"]        = $forecast->location;
                                     } else {
                                         $difference     = 0;
-                                        
+
                                         if ($toHour >= $fromHour) {
                                             $difference = $toHour - $fromHour;
                                         } else {
                                             $difference = (24 - $fromHour) + $toHour;
                                         }
-                                        
+
                                         if (!isset($forecast->location->precipitation) || !isset($forecast->location->symbol)) {
                                             throw new Exception("The XML is invalid - precipitation or symbol not defined", METno::XML_INVALID);
                                         }
-                                        
+
                                         $symbolAttributes           = $forecast->location->symbol->attributes();
                                         $precipitationAttributes    = $forecast->location->precipitation->attributes();
-                                                                                
+
                                         $forecastByDay[$fromDate][$fromHour]["symbols"][$toHour]     = array(
                                             "from"          => $fromHour,       // from hour
                                             "to"            => $toHour,         // to hour
                                             "difference"    => $difference,     // difference in hours betwen from to to
                                             "symbol"        => new self::$classSymbol(self::getAttributeValue($symbolAttributes, "number",0),
-                                                                                     self::getAttributeValue($symbolAttributes, "id")),                                            
-                                            "precipitation" => new self::$classPrecipitation(self::getAttributeValue($precipitationAttributes, "value",1), 
-                                                                                     self::getAttributeValue($precipitationAttributes, "minvalue",1), 
+                                                                                     self::getAttributeValue($symbolAttributes, "id")),
+                                            "precipitation" => new self::$classPrecipitation(self::getAttributeValue($precipitationAttributes, "value",1),
+                                                                                     self::getAttributeValue($precipitationAttributes, "minvalue",1),
                                                                                      self::getAttributeValue($precipitationAttributes, "maxvalue",1))
                                         );
-                                        
+
                                     }
-                                    
+
                                     $previousDay = $fromDate;
                                     $lastForeCast = $forecast;
-                                    
-                                } else throw new Exception("The XML is invalid - the date detection failed", METno::XML_INVALID);  
+
+                                } else throw new Exception("The XML is invalid - the date detection failed", METno::XML_INVALID);
                             } else throw new Exception("The XML is invalid - the from and to attribute is invalid", METno::XML_INVALID);
                         } else throw new Exception("The XML is invalid - time node attributes", METno::XML_INVALID);
-                    } else throw new Exception("The XML is invalid - location node is missing", METno::XML_INVALID); 
+                    } else throw new Exception("The XML is invalid - location node is missing", METno::XML_INVALID);
                 }
-                
+
                 $previousDay = null;
                 $forecast = null;
-                
-                if (!empty($forecastByDay)) {      
+
+                if (!empty($forecastByDay)) {
                     // sort by date, the xml can return today date before yesterday
                     ksort($forecastByDay);
-                    
+
                     // Create days
                     foreach ($forecastByDay as $date => $forecast) {
                         $this->forecastByDay[$date] = new METnoDay($date, $forecast,$this);
                     }
                     return $this->forecastByDay;
-                } else throw new Exception("The weather information is empty", METno::DATA_EMPTY); 
-                
+                } else throw new Exception("The weather information is empty", METno::DATA_EMPTY);
+
                 return $this->forecastByDay;
             } catch (Exception $exc) {
                 return $this->error($exc);
@@ -388,7 +389,7 @@ class METno extends METnoFactory {
         }
         return false;
     }
-    
+
     /**
      * Gets forecast XML by location and detects if the base structure is valide
      * and returns it for other use
@@ -396,42 +397,42 @@ class METno extends METnoFactory {
      * @throws Exception
      */
     protected function getForecastXML() {
-        
+
         try {
             $cacheSubFolder     = date("Ymd")."/";
             $cacheFileName      = self::$cacheDir.$cacheSubFolder.$this->apiParameters."-".date("H").".xml"; // prepare name of cache file by hour
-                        
-            if (file_exists($cacheFileName)) {                
+
+            if (file_exists($cacheFileName)) {
                 $xml            = simplexml_load_file($cacheFileName);
             } else {
-                
+
                 $apiResponse    = $this->sendRequest($this->apiRequest.$this->apiParameters); // send request to api
-                
+
                 if (is_bool($apiResponse)) { // failed to download file and on die is false
                     return false;
                 }
-                
+
                 if (!is_dir(self::$cacheDir)) { // cache folder is not created
                     mkdir(self::$cacheDir);
                 }
-                
+
                 if (!is_dir(self::$cacheDir.$cacheSubFolder)) {
                     mkdir(self::$cacheDir.$cacheSubFolder);
                 }
-                
-                $xml            = simplexml_load_string($apiResponse);     
-                
+
+                $xml            = simplexml_load_string($apiResponse);
+
                 /**
                  * Create hour cache file and delete previous cache file HOUR - 1
                  */
                 $cache          = fopen($cacheFileName, "w");
-                
+
                 fwrite($cache, $apiResponse);
-                fclose($cache);  
-                
+                fclose($cache);
+
                 // remove the previous hour
                 $previousHour   = date("H",strtotime("-1 HOUR"));
-                
+
                 $cacheFileOld   = self::$cacheDir.$cacheSubFolder.$this->apiParameters."-".$previousHour.".xml";
 
                 if (file_exists($cacheFileOld)) {
@@ -439,16 +440,16 @@ class METno extends METnoFactory {
                 }
 
                 // remove the previous day
-                
+
                 $cacheSubFolder     = date("Ymd",strtotime("-1 DAY"))."/";
-                    
+
                 if (is_dir(self::$cacheDir.$cacheSubFolder)) {
                     $this->rmdirRecursively(self::$cacheDir.$cacheSubFolder);
                 }
             }
-            
+
             if (!is_bool($xml) && isset($xml->product) && is_object($xml->product) && isset($xml->product->time)) {
-                return $xml;                
+                return $xml;
             } else {
                 throw new Exception("The XML is invalid", METno::XML_INVALID);
             }
@@ -469,9 +470,9 @@ class METno extends METnoFactory {
         }
         return @rmdir($dir);
     }
-    
+
     /**
-     * 
+     *
      * @param type $date date in Y-m-d format
      * @return METnoForecast
      */
@@ -479,11 +480,11 @@ class METno extends METnoFactory {
         if (empty($this->forecastByDay)) {
             $this->getForecast();
         }
-        
+
         if (isset($this->forecastByDay[$date])) {
             return $this->forecastByDay[$date];
         }
-        
+
         return $this->error(new Exception("Forecast for date $date doesn't exist", METno::DATA_EMPTY));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php" : ">=5.3.0",
         "ext-curl" : "*"
+        "ext-dom" : "*"
     },
     "autoload" : {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "pion/metno",
+    "name": "neogenia/metno",
     "version" : "1.0.1",
     "description": "MET.no API library for fetching weather forecast",
     "type" : "library",
@@ -7,9 +7,9 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "Martin Kluska",
-            "email": "martin.kluska@imakers.cz",
-            "homepage" : "http://imakers.cz"
+            "name": "Vitezslav Ondracek",
+            "email": "vitezslav.ondracek@neogenia.cz",
+            "homepage" : "http://www.neogenia.cz"
         }
     ],
     "minimum-stability": "dev",

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ You can install this library via composer or download the classes and to load al
 
 Add to composer require
 
-	"pion/metno": ">=1.0.0"
+	"neogenia/metno": ">=1.0.0"
 
 For best clean of cached xml files use a cron with sh script like this (delete files older than 1 day):
 


### PR DESCRIPTION
Update endpointu na METno, verze 1.9 je už deprecated, změněno na 2.0. Bylo nutné do endpointu přidat `classic`, ať vrací XML, se kterým teď balíček počítá, data by měla být stejná.

Dále upravena kontrola response z METno. Balíček natvrdo kontroloval stavový kód 200. U endpointu na verzi METno 1.9 se vracelo 203, u verze 2.0 se vrací 304, pokud není obsah změněn. Upraveno tedy tak, že kontroluje jen validní XML.

Jinak composer.json a readme.md asi nebylo z dřívějška mergnuto do masteru, protože jsou nyní uvedeny jako změněné, ale ty změny jsou tam už z roku 2018, dle historie gitu. Já jen přidával `ext-dom`