### PR TITLE
Changed metNo api version to working one

### DIFF
--- a/METno.php
+++ b/METno.php
@@ -19,7 +19,7 @@
  */
 class METno extends METnoFactory {
 
-    protected $apiRequest       = "https://api.met.no/weatherapi/locationforecast/1.9/?";
+    protected $apiRequest       = "https://api.met.no/weatherapi/locationforecast/2.0/classic.xml?";
     protected $apiParameters    = "";
 
     /**


### PR DESCRIPTION
Recently this library stopped working. Reason is 1.9 version of metNo api is no longer supported. This commit changes version to 2.0 which is working.